### PR TITLE
Use the same USB device that the log message promises to use

### DIFF
--- a/zytempmqtt/ZyTemp.py
+++ b/zytempmqtt/ZyTemp.py
@@ -162,5 +162,5 @@ def get_hiddev():
 
     l.log(log.INFO, f'Using device at {p[0].decode("utf-8")}')
     h = hid.device()
-    h.open_path(path)
+    h.open_path(p[0])
     return h


### PR DESCRIPTION
Previously, the code would log the name of the USB device it was planning to open, but then inadvertently used a different variable (from an earlier loop) to actually open the device, which was different if multiple matching USB devices are present.