### PR TITLE
Optionally decrypt data from sensor device

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ mqtt_client_id: foobar          # MQTT client ID (default: zytemp-mqtt)
 mqtt_topic: /foo/bar            # MQTT topic (default: zytemp-mqtt)
 friendly_name: aircontrol       # Friendly name for HomeAssistant (default: zytemp-mqtt)
 discovery_prefix: homeassistant # Discovery prefix for HomeAssistant (default: homeassistant)
+decrypt: False                  # Decrypt data from zyTemp, may be needed for some devices (default: False)
 ```
 
 ## Home Assistant integration

--- a/zytempmqtt/config.py
+++ b/zytempmqtt/config.py
@@ -15,6 +15,7 @@ class ConfigFile(object):
         'mqtt_topic': APPLICATION_NAME,
         'friendly_name': APPLICATION_NAME,
         'discovery_prefix': 'homeassistant',
+        'decrypt': False,
     }
 
     _instance = None


### PR DESCRIPTION
Some devices (e.g., co2meter.com's RAD-0301) encrypt the 8-byte data they send.  This change adds support for decrypting the message, based on the nice Python implementation of this in https://github.com/vfilimonov/co2meter/blob/master/co2meter/co2meter.py which, in turn, I think ultimately derives from the reverse-engineering described in https://hackaday.io/project/5301/logs?sort=oldest

Since not every device seems to require this decryption, there is now a "decrypt" config field that determines whether the data from the device should be decrypted, defaulting to False (the existing behavior).