### PR TITLE
retry discovery if publish did not succeed

### DIFF
--- a/zytempmqtt/ZyTemp.py
+++ b/zytempmqtt/ZyTemp.py
@@ -41,6 +41,7 @@ class ZyTemp():
         self.h.send_feature_report(b'\xc4\xc6\xc0\x92\x40\x23\xdc\x96')
         self.measurements_to_ignore = IGNORE_N_MEASUREMENTS
         self.values = {v['name']: None for v in ZyTemp.MEASUREMENTS.values()}
+        self.discover_published = False
 
     def __del__(self):
         self.h.close()
@@ -49,6 +50,9 @@ class ZyTemp():
 
     def discovery(self):
         if not len(self.cfg.discovery_prefix):
+            return
+
+        if self.discover_published:
             return
 
         for meas in ZyTemp.MEASUREMENTS.values():
@@ -70,13 +74,15 @@ class ZyTemp():
                 'value_template': '{{ value_json.%s }}' % meas['name'],
                 'icon': meas['ha_icon']
             }
-            self.m.publish(
+            res = self.m.publish(
                 os.path.join(
                     self.cfg.discovery_prefix, 'sensor', config_content['unique_id'], 'config'
                 ),
                 config_content,
                 retain=True
             )
+            if res:
+                self.discover_published = True
 
         self.m.run(0.1)
 
@@ -92,8 +98,8 @@ class ZyTemp():
         self.m.publish(self.cfg.mqtt_topic, self.values)
 
     def run(self):
-        self.discovery()
         while True:
+            self.discovery()
             try:
                 r = self.h.read(8)
             except OSError as err:

--- a/zytempmqtt/mqtt.py
+++ b/zytempmqtt/mqtt.py
@@ -50,8 +50,11 @@ class MqttClient:
                 return [round_floats(x) for x in o]
             return o
         if self.connected:
-            self.client.publish(topic, json.dumps(
+            mi = self.client.publish(topic, json.dumps(
                 round_floats(pkt)), retain=retain)
+            return (mi.rc == mqtt.MQTT_ERR_SUCCESS)
+        else:
+            return False
 
     def run(self, to):
         if not self.connected:


### PR DESCRIPTION
On initial startup, when discovery() calls publish(), the MQTT client might not be connected yet.  Keep trying to publish the discovery information until the publish call succeeds.