### PR TITLE
Report relative humidity (tested on TFA Airco2ntrol)

### DIFF
--- a/zytempmqtt/ZyTemp.py
+++ b/zytempmqtt/ZyTemp.py
@@ -42,6 +42,13 @@ class ZyTemp():
             'ha_device_class': 'carbon_dioxide',
             'ha_icon': 'mdi:molecule-co2',
         },
+        0x41: {
+            'name': 'Humidity',
+            'unit': '%',
+            'conversion': lambda x: x / 100,
+            'ha_device_class': 'humidity',
+            'ha_icon': 'mdi:water-percent',
+        },
     }
 
     def __init__(self, hiddev, mqtt):


### PR DESCRIPTION
This adds relative humidity reporting on the TFA Airco2ntrol, I am not sure if other devices use the same entry point though. I think back in November when I wrote it I saw mentions of other entry points, but hopefully none re-use the same entry point for a different value...