### PR TITLE
Support for availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ mqtt_username: user             # MQTT username
 mqtt_password: pass             # MQTT password
 mqtt_client_id: foobar          # MQTT client ID (default: zytemp-mqtt)
 mqtt_topic: /foo/bar            # MQTT topic (default: zytemp-mqtt)
+availability_topic: /foo/bar    # MQTT topic reporting availability (default: zytemp-mqtt/availability)
 friendly_name: aircontrol       # Friendly name for HomeAssistant (default: zytemp-mqtt)
 discovery_prefix: homeassistant # Discovery prefix for HomeAssistant (default: homeassistant)
 decrypt: False                  # Decrypt data from zyTemp, may be needed for some devices (default: False)

--- a/zytempmqtt/ZyTemp.py
+++ b/zytempmqtt/ZyTemp.py
@@ -89,6 +89,7 @@ class ZyTemp():
                 'device_class': meas['ha_device_class'],
                 'name': ' '.join((self.cfg.friendly_name, meas['name'])),
                 'state_topic': self.cfg.mqtt_topic,
+                'availability_topic': self.cfg.availability_topic,
                 'unique_id': '_'.join((id, meas['name'])),
                 'unit_of_measurement': meas['unit'],
                 'value_template': '{{ value_json.%s }}' % meas['name'],

--- a/zytempmqtt/config.py
+++ b/zytempmqtt/config.py
@@ -13,6 +13,7 @@ class ConfigFile(object):
         'mqtt_password': None,
         'mqtt_client_id': APPLICATION_NAME,
         'mqtt_topic': APPLICATION_NAME,
+        'availability_topic': os.path.join(APPLICATION_NAME, 'availability'),
         'friendly_name': APPLICATION_NAME,
         'discovery_prefix': 'homeassistant',
         'decrypt': False,

--- a/zytempmqtt/mqtt.py
+++ b/zytempmqtt/mqtt.py
@@ -16,6 +16,7 @@ class MqttClient:
         self.connected = (rc == 0)
         if rc == 0:
             l.log(log.INFO, f'connected to {self.cfg.mqtt_host}')
+            self.client.publish(self.cfg.availability_topic, "online", retain=True)
         else:
             l.log(log.ERROR,
                   f'connection to {self.cfg.mqtt_host} failed: {rc}')
@@ -26,6 +27,7 @@ class MqttClient:
 
     def connect(self):
         self.client = mqtt.Client(client_id=self.cfg.mqtt_client_id)
+        self.client.will_set(self.cfg.availability_topic, "offline", retain=True)
         self.client.on_connect = self.on_connect
         self.client.on_disconnect = self.on_disconnect
         self.client.username_pw_set(


### PR DESCRIPTION
This makes Home Assistant display the entities as unavailable as soon as the service stops running or is disconnected or something.