### PR TITLE
add backwards compatible fix for paho2

### DIFF
--- a/zytempmqtt/mqtt.py
+++ b/zytempmqtt/mqtt.py
@@ -26,9 +26,9 @@ class MqttClient:
 
     def connect(self):
         try:
-            mqtt_client = mqtt.Client(callback_api_version=mqtt.CallbackAPIVersion.VERSION1, client_id=self.cfg.mqtt_client_id)
+            self.client = mqtt.Client(callback_api_version=mqtt.CallbackAPIVersion.VERSION1, client_id=self.cfg.mqtt_client_id)
         except AttributeError:
-            mqtt_client = mqtt.Client(client_id=self.cfg.mqtt_client_id)
+            self.client = mqtt.Client(client_id=self.cfg.mqtt_client_id)
         self.client.on_connect = self.on_connect
         self.client.on_disconnect = self.on_disconnect
         self.client.username_pw_set(

--- a/zytempmqtt/mqtt.py
+++ b/zytempmqtt/mqtt.py
@@ -25,7 +25,10 @@ class MqttClient:
         l.log(log.WARN, f'disconnected from {self.cfg.mqtt_host}: {rc}')
 
     def connect(self):
-        self.client = mqtt.Client(client_id=self.cfg.mqtt_client_id)
+        try:
+            mqtt_client = mqtt.Client(callback_api_version=mqtt.CallbackAPIVersion.VERSION1, client_id=self.cfg.mqtt_client_id)
+        except AttributeError:
+            mqtt_client = mqtt.Client(client_id=self.cfg.mqtt_client_id)
         self.client.on_connect = self.on_connect
         self.client.on_disconnect = self.on_disconnect
         self.client.username_pw_set(


### PR DESCRIPTION
This is due to paho-mqtt just releasing 2.0.0 which has a [breaking change listed here](https://github.com/eclipse/paho.mqtt.python/blob/v2.0.0/docs/migrations.rst).