### PR TITLE
Add timeout for reading

### DIFF
--- a/zytempmqtt/ZyTemp.py
+++ b/zytempmqtt/ZyTemp.py
@@ -128,7 +128,7 @@ class ZyTemp():
         while True:
             self.discovery()
             try:
-                r = self.h.read(8)
+                r = self.h.read(8, timeout_ms = 60 * 1000)
             except OSError as err:
                 l.log(log.ERROR, f'OS error: {err}')
                 return


### PR DESCRIPTION
This permits catching more errors, notably when putting the computer to sleep: no data can be read anymore.
Adding a timeout, in addition to the existing error handling,  allows recovering from that.

Put 60 seconds to be conservative, maybe there are other devices out there who report less often than the every 2-3 seconds that I have with my device.